### PR TITLE
add compiler option "-std=c99"

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -4,3 +4,4 @@ setup.py
 dvdread/__init__.py
 dvdread/objects.py
 src/dvdread.c
+src/dvdread.h

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+include README
+include setup.py
+recursive-include dvdread *.py
+recursive-include src *.c *h
+

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,8 @@ dvdread4 = Extension(
 	],
         include_dirs = ['/usr/include'],
 	libraries = ['dvdread'],
-	sources = ['src/dvdread.c']
+	sources = ['src/dvdread.c'],
+	extra_compile_args = ['-std=c99']
 )
 
 setup(


### PR DESCRIPTION
This adds the compiler option `-std=c99` during the build process and partially resolves https://github.com/cmlburnett/PyDvdRead/issues/1
